### PR TITLE
introduced strip single parent config option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>org.tap4j</groupId>
 			<artifactId>tap4j</artifactId>
-			<version>4.1.2</version>
+			<version>4.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/resources/org/tap4j/plugin/TapPublisher/config.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapPublisher/config.jelly
@@ -37,5 +37,8 @@
       <f:entry title="Show only failures">
           <f:checkbox name="TapPublisher.showOnlyFailures" value="${instance.showOnlyFailures}" checked="${instance.showOnlyFailures}" default="false" />
       </f:entry>
+      <f:entry title="Strip single parents">
+          <f:checkbox name="TapPublisher.stripSingleParents" value="${instance.stripSingleParents}" checked="${instance.stripSingleParents}" default="false" />
+      </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/test/java/org/tap4j/plugin/stripsingleparent/TestStripSingleParent.java
+++ b/src/test/java/org/tap4j/plugin/stripsingleparent/TestStripSingleParent.java
@@ -1,0 +1,101 @@
+package org.tap4j.plugin.stripsingleparent;
+
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleProject;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.TestBuilder;
+import org.tap4j.plugin.TapPublisher;
+import org.tap4j.plugin.TapResult;
+import org.tap4j.plugin.TapTestResultAction;
+
+/**
+ * At least basic tests for strip single parent configuration option.
+ *
+ * @author Jakub Podlesak
+ */
+public class TestStripSingleParent extends HudsonTestCase {
+
+    public void testNoEffect() throws IOException, InterruptedException, ExecutionException {
+
+        final String tap = "1..2\n" +
+                "ok 1 - 1\n" +
+                "  1..3\n" +
+                "  ok 1 1.1\n" +
+                "  ok 2 1.2\n" +
+                "  ok 3 1.3\n" +
+                "ok 2 - 1\n";
+
+        _test(tap, 2);
+    }
+
+    public void testStripFirstLevel() throws IOException, InterruptedException, ExecutionException {
+
+        final String tap = "1..1\n" +
+                "ok 1 - 1\n" +
+                "  1..3\n" +
+                "  ok 1 1.1\n" +
+                "  ok 2 1.2\n" +
+                "  ok 3 1.3\n";
+
+        _test(tap, 3);
+    }
+
+    public void testStripSecondLevel() throws IOException, InterruptedException, ExecutionException {
+
+        final String tap =
+                "1..1\n" +
+                "ok 1 - 1\n" +
+                "  1..1\n" +
+                "  ok 1.1 - 1\n" +
+                "    1..3\n" +
+                "    ok 1 1.1.1\n" +
+                "    ok 2 1.1.2\n" +
+                "    ok 3 1.1.3\n";
+
+        _test(tap, 3);
+    }
+
+    private void _test(final String tap, int expectedTotal) throws IOException, InterruptedException, ExecutionException {
+        FreeStyleProject project = this.hudson.createProject(FreeStyleProject.class, "strip-single-parents");
+
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher arg1,
+                    BuildListener arg2) throws InterruptedException, IOException {
+                build.getWorkspace().child("result.tap").write(tap,"UTF-8");
+                return true;
+            }
+        });
+
+        TapPublisher publisher = new TapPublisher(
+                "result.tap", // test results
+                true,  // failIfNoResults
+                true,  // failedTestsMarkBuildAsFailure
+                false, // outputTapToConsole
+                true,  // enableSubtests
+                true,  // discardOldReports
+                true,  // todoIsFailure
+                true,  // includeCommentDiagnostics
+                true,  // validateNumberOfTests
+                true,  // planRequired
+                false, // verbose
+                true,  // showOnlyFailures
+                true); // stripSingleParents
+
+        project.getPublishersList().add(publisher);
+        project.save();
+        FreeStyleBuild build = (FreeStyleBuild) project.scheduleBuild2(0).get();
+
+        TapTestResultAction action = build.getAction(TapTestResultAction.class);
+        TapResult testResult = action.getTapResult();
+
+        assertEquals(expectedTotal, testResult.getPassed());
+    }
+}

--- a/src/test/java/org/tap4j/plugin/stripsingleparent/package-info.java
+++ b/src/test/java/org/tap4j/plugin/stripsingleparent/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Tests stripping single parent feature.
+ */
+package org.tap4j.plugin.stripsingleparent;


### PR DESCRIPTION
The new option should be handy if you have to process a TAP file like the following one:

```
1..1
not ok 1
  1..1024
  ok 1 test 1
  ok 2 test 2
  not ok 3 test 3
  ok 4 test 4
  ...
```

The new feature is disabled by default, so that it does not break existing behaviour.
I have also bumped the TAP parser version to 4.2.0.
